### PR TITLE
Run travis on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
   - "6.2"
   - "iojs"
   - "stable"
+all_branches: true
 notifications:
   email:
     - dylan.pulliam@gmail.com


### PR DESCRIPTION
Travis was not running on master by default. I wanted to add a config to just run on all branches until there's a reason not to. 
